### PR TITLE
Update the build_routes function

### DIFF
--- a/lib/sinatra_static.rb
+++ b/lib/sinatra_static.rb
@@ -9,37 +9,37 @@ class SinatraStatic
   require 'term/ansicolor'
   class ColorString < String
     include Term::ANSIColor
-  end  
-  
-  def initialize(app)    
-    @app = app    
+  end
+
+  def initialize(app)
+    @app = app
   end
 
   def build!(dir)
     handle_error_no_each_route! unless @app.respond_to?(:each_route)
-    handle_error_dir_not_found!(dir) unless dir_exists?(dir)     
+    handle_error_dir_not_found!(dir) unless dir_exists?(dir)
     build_routes(dir)
   end
 
 private
 
   def build_routes(dir)
-    @app.each_route do |route|     
-      next unless route.verb == 'GET'      
+    @app.each_route do |route|
+      next if route.verb != 'GET' or not route.path.is_a? String
       build_path(route.path, dir)
-    end    
-  end 
+    end
+  end
 
-  def build_path(path, dir)                 
+  def build_path(path, dir)
     ::FileUtils.mkdir_p(dir_for_path(path, dir))
-    ::File.open(file_for_path(path, dir), 'w+') do |f| 
-      f.write(get_path(path).body) 
-    end    
+    ::File.open(file_for_path(path, dir), 'w+') do |f|
+      f.write(get_path(path).body)
+    end
   end
 
   def get_path(path)
-    self.get(path).tap do |resp|      
-      handle_error_non_200!(path) unless resp.status == 200           
+    self.get(path).tap do |resp|
+      handle_error_non_200!(path) unless resp.status == 200
     end
   end
 
@@ -55,8 +55,8 @@ private
     ::File.exists?(dir) && ::File.directory?(dir)
   end
 
-  def dir_for_path(path, dir)   
-    file_for_path(path, dir).match(/(.*)\/[^\/]+$/)[1]  
+  def dir_for_path(path, dir)
+    file_for_path(path, dir).match(/(.*)\/[^\/]+$/)[1]
   end
 
   def file_extensions
@@ -65,13 +65,13 @@ private
 
   def env
     ENV['RACK_ENV']
-  end  
+  end
 
   def handle_error_no_each_route!
     handle_error!("can't call app.each_route, did you include sinatra-advanced-routes?")
   end
 
-  def handle_error_dir_not_found!(dir)  
+  def handle_error_dir_not_found!(dir)
     handle_error!("can't find output directory: #{dir}")
   end
 
@@ -79,7 +79,7 @@ private
     handle_error!("GET #{path} returned non-200 status code...")
   end
 
-  def handle_error!(desc)    
+  def handle_error!(desc)
     puts ColorString.new("failed: #{desc}").red; exit!
   end
 


### PR DESCRIPTION
The build_routes -function is now updated to work proper with the "sinatra-assetpack" - Gem together and prevent a Type-Error because of regex-paths.
